### PR TITLE
Dragging Child Elements within Custom Panel

### DIFF
--- a/src/SplitPane.elm
+++ b/src/SplitPane.elm
@@ -523,8 +523,8 @@ domInfo =
         (Json.maybe ("clientY" := Json.int))
         (Json.maybe (at [ "touches", "0", "clientX" ] Json.int))
         (Json.maybe (at [ "touches", "0", "clientY" ] Json.int))
-        (at [ "target", "parentElement", "clientWidth" ] Json.int)
-        (at [ "target", "parentElement", "clientHeight" ] Json.int)
+        (at [ "currentTarget", "parentElement", "clientWidth" ] Json.int)
+        (at [ "currentTarget", "parentElement", "clientHeight" ] Json.int)
 
 
 


### PR DESCRIPTION
* Fixes #2 
* Receives the parent of the panel even when child elements are selected

![after](https://cloud.githubusercontent.com/assets/1934592/24841028/593bbc6a-1d48-11e7-8330-c533d7eaea09.gif)
