### PR TITLE
Avoid unnecessary subscriptions

### DIFF
--- a/src/SplitPane.elm
+++ b/src/SplitPane.elm
@@ -536,7 +536,7 @@ domInfo =
 subscriptions : State -> Sub Msg
 subscriptions (State state) =
     case state.dragState of
-        Draggable _ ->
+        Draggable (Just _) ->
             Sub.batch
                 [ Mouse.moves SplitterMove
                 , Mouse.ups SplitterLeftAlone


### PR DESCRIPTION
I saw messages are coming while I'm not dragging the splitter.
This should fix it.